### PR TITLE
fix: twitch emote fetching

### DIFF
--- a/src/struct/EmoteFetcher.js
+++ b/src/struct/EmoteFetcher.js
@@ -51,7 +51,7 @@ class EmoteFetcher {
             : Constants.Twitch.Channel(id); // eslint-disable-line new-cap
 
         return got(endpoint, options)
-            .then(req => req.json())
+            .then(req => req.body)
             .catch(err => {
                 if (!id) {
                     // If fetching global didn't work, try with fallback


### PR DESCRIPTION
Seems like .json() throws a TypeError, so fetching twitch channel emotes does not work for me.